### PR TITLE
Made checklist creation easier, and fixed a small bug

### DIFF
--- a/lib/model/item.dart
+++ b/lib/model/item.dart
@@ -16,6 +16,9 @@ class Item {
 
   Item([this.value = '', this.itemType = ItemType.text]);
 
+  // This method is needed to update the fields of a cached `Item` 
+  // in the `IsarLinks` of a `ListModel` with the same `id` as `this`, 
+  // but out-of-date fields (see `ListModel.update()`)
   void copyOnto(Item item) {
     item.value = value;
     item.itemType = itemType;

--- a/lib/model/item.dart
+++ b/lib/model/item.dart
@@ -15,6 +15,12 @@ class Item {
   bool isChecked = false;
 
   Item([this.value = '', this.itemType = ItemType.text]);
+
+  void copyOnto(Item item) {
+    item.value = value;
+    item.itemType = itemType;
+    item.isChecked = isChecked;
+  }
 }
 
 enum ItemType { text, checkbox }

--- a/lib/model/list_model.dart
+++ b/lib/model/list_model.dart
@@ -55,8 +55,7 @@ class ListModel {
     if (items.contains(item)) {
       await DatabaseManager.putItem(item);
       // The following ensures that the copy of `item` that `this` has is up to date.
-      items.remove(item);
-      items.add(item);
+      item.copyOnto(items.lookup(item)!);
     } else {
       throw ItemUpdateError(item: item, listModel: this);
     }

--- a/lib/model/list_model.dart
+++ b/lib/model/list_model.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:isar/isar.dart';
 import 'package:lists/model/database_manager.dart';
 import 'package:lists/model/item.dart';
@@ -14,13 +15,16 @@ class ListModel {
 
   final items = IsarLinks<Item>();
 
+  ItemType getDefaultItemType() => items.lastOrNull?.itemType ?? ItemType.text;
+
   Iterable<Item> itemsView() => items;
 
   // a zero-arg constructor is required for classes that are isar collections
   ListModel();
   ListModel.fromTitle(this.title);
 
-  void init() => items.loadSync();
+  void init() => reload();
+  void reload() => items.loadSync();
 
   Future<Iterable<Item>> searchItems(String searchStr) {
     final words = _parseSearchStr(searchStr);

--- a/lib/model/list_model.dart
+++ b/lib/model/list_model.dart
@@ -15,7 +15,8 @@ class ListModel {
 
   final items = IsarLinks<Item>();
 
-  ItemType getDefaultItemType() => items.lastOrNull?.itemType ?? ItemType.text;
+  @ignore
+  ItemType get lastItemType => items.lastOrNull?.itemType ?? ItemType.text;
 
   Iterable<Item> itemsView() => items;
 
@@ -53,6 +54,9 @@ class ListModel {
   Future<void> update(Item item) async {
     if (items.contains(item)) {
       await DatabaseManager.putItem(item);
+      // The following ensures that the copy of `item` that `this` has is up to date.
+      items.remove(item);
+      items.add(item);
     } else {
       throw ItemUpdateError(item: item, listModel: this);
     }

--- a/lib/view/list_widget.dart
+++ b/lib/view/list_widget.dart
@@ -73,7 +73,8 @@ class _ListWidgetState extends State<ListWidget> {
           .toList());
 
   void _addNewItem() async {
-    final newItem = Item('', listModel.getDefaultItemType());
+    // Imitate the type of the last item.
+    final newItem = Item('', listModel.lastItemType);
 
     if (context.mounted) {
       showDialog(

--- a/lib/view/list_widget.dart
+++ b/lib/view/list_widget.dart
@@ -24,6 +24,7 @@ class _ListWidgetState extends State<ListWidget> {
   @override
   void initState() {
     super.initState();
+    listModel.reload();
     itemsToBeDisplayed = listModel.itemsView();
   }
 
@@ -72,7 +73,7 @@ class _ListWidgetState extends State<ListWidget> {
           .toList());
 
   void _addNewItem() async {
-    final newItem = Item();
+    final newItem = Item('', listModel.getDefaultItemType());
 
     if (context.mounted) {
       showDialog(


### PR DESCRIPTION
When an item is edited after searching, sometimes, it would not update in the app after the user went out of the list and coming back (though it would in the database). 

I made the default item type for a new item the item type of the last item in `items`.

Closes #25
