### PR TITLE
Don't allow empty inputs

### DIFF
--- a/lib/view/edit_item_dialog.dart
+++ b/lib/view/edit_item_dialog.dart
@@ -20,6 +20,7 @@ class _EditItemDialogState extends State<EditItemDialog> {
   @override
   void initState() {
     _editingController = TextEditingController(text: widget.item.value);
+    _editingController.addListener(() => setState(() {}));
     super.initState();
   }
 
@@ -33,7 +34,9 @@ class _EditItemDialogState extends State<EditItemDialog> {
           TextFormField(
             controller: _editingController,
             autofocus: true,
-            onFieldSubmitted: (_) => _submitNewItemValue(),
+            onFieldSubmitted: (value) {
+              if (!_isBlank(value)) _submitNewItemValue();
+            },
           ),
           const SizedBox(height: 15),
           _buildItemTypeSwitcher()
@@ -41,12 +44,17 @@ class _EditItemDialogState extends State<EditItemDialog> {
       ),
       actions: [
         ElevatedButton(
-          onPressed: () => _submitNewItemValue(),
+          // if the text value for the item is blank, this button is disabled (onPressed == null),
+          // because we don't want the user to be able to add blank/empty items.
+          onPressed:
+              !_isBlank(_editingController.text) ? _submitNewItemValue : null,
           child: const Text('Submit'),
         )
       ],
     );
   }
+
+  bool _isBlank(String str) => str.trim().isEmpty;
 
   Widget _buildItemTypeSwitcher() => Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/view/edit_item_dialog.dart
+++ b/lib/view/edit_item_dialog.dart
@@ -20,6 +20,7 @@ class _EditItemDialogState extends State<EditItemDialog> {
   @override
   void initState() {
     _editingController = TextEditingController(text: widget.item.value);
+    // Update the state of the submit button when the user input changes
     _editingController.addListener(() => setState(() {}));
     super.initState();
   }

--- a/lib/view/edit_item_dialog.dart
+++ b/lib/view/edit_item_dialog.dart
@@ -35,7 +35,8 @@ class _EditItemDialogState extends State<EditItemDialog> {
             controller: _editingController,
             autofocus: true,
             onFieldSubmitted: (value) {
-              if (!_isBlank(value)) _submitNewItemValue();
+              // we don't want the user to be able to add blank/empty items.
+              if (!_isValueBlank) _submitNewItemValue();
             },
           ),
           const SizedBox(height: 15),
@@ -45,16 +46,15 @@ class _EditItemDialogState extends State<EditItemDialog> {
       actions: [
         ElevatedButton(
           // if the text value for the item is blank, this button is disabled (onPressed == null),
-          // because we don't want the user to be able to add blank/empty items.
-          onPressed:
-              !_isBlank(_editingController.text) ? _submitNewItemValue : null,
+          // because we don't want the user to be able to submit blank/empty items.
+          onPressed: !_isValueBlank ? _submitNewItemValue : null,
           child: const Text('Submit'),
         )
       ],
     );
   }
 
-  bool _isBlank(String str) => str.trim().isEmpty;
+  bool get _isValueBlank => _editingController.text.trim().isEmpty;
 
   Widget _buildItemTypeSwitcher() => Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/view/list_settings_dialog.dart
+++ b/lib/view/list_settings_dialog.dart
@@ -20,6 +20,7 @@ class _ListSettingsDialogState extends State<ListSettingsDialog> {
   @override
   void initState() {
     _editingController = TextEditingController(text: widget.listModel.title);
+    // Update the state of the submit button when the user input changes
     _editingController.addListener(() => setState(() {}));
     super.initState();
   }

--- a/lib/view/list_settings_dialog.dart
+++ b/lib/view/list_settings_dialog.dart
@@ -8,9 +8,7 @@ class ListSettingsDialog extends StatefulWidget {
   final ListModel listModel;
 
   const ListSettingsDialog(
-      {super.key,
-      required this.onSubmit,
-      required this.listModel});
+      {super.key, required this.onSubmit, required this.listModel});
 
   @override
   State<ListSettingsDialog> createState() => _ListSettingsDialogState();
@@ -22,6 +20,7 @@ class _ListSettingsDialogState extends State<ListSettingsDialog> {
   @override
   void initState() {
     _editingController = TextEditingController(text: widget.listModel.title);
+    _editingController.addListener(() => setState(() {}));
     super.initState();
   }
 
@@ -32,18 +31,25 @@ class _ListSettingsDialogState extends State<ListSettingsDialog> {
       content: TextFormField(
         controller: _editingController,
         autofocus: true,
-        onFieldSubmitted: (_) => _submitNewItemValue(),
+        onFieldSubmitted: (value) {
+          // we don't want the user to be able to submit blank/empty items.
+          if (!_isTitleBlank) _submitListModel();
+        },
       ),
       actions: [
         ElevatedButton(
-          onPressed: () => _submitNewItemValue(),
+          // if the title is blank, this button is disabled (onPressed == null),
+          // because we don't want the user to be able to submit lists with blank titles.
+          onPressed: !_isTitleBlank ? _submitListModel : null,
           child: const Text('Submit'),
         )
       ],
     );
   }
 
-  void _submitNewItemValue() {
+  bool get _isTitleBlank => _editingController.text.trim().isEmpty;
+
+  void _submitListModel() {
     Navigator.pop(context);
     widget.listModel.title = _editingController.text;
     widget.onSubmit(widget.listModel);


### PR DESCRIPTION
In `ListSettingsDialog`, I renamed `_submitNewItemValue` to `_submitListModel`.

The code for making sure empty items and lists with empty titles are never submitted was practically the same in both cases, so I decided to put them into one PR.

Are my comments descriptive? Necessary? Did I violate the DRY principle with `_isValueBlank` and `_isTitleBlank`? Need renaming?

Closes #28