### PR TITLE
Removed Modal Bottom Sheet From HomePage

### DIFF
--- a/lib/view/edit_item_dialog.dart
+++ b/lib/view/edit_item_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lists/model/item.dart';
+import 'package:lists/view/submit_button.dart';
 
 /// EditItemDialog:
 ///   - a dialog that allows the user to edit an `Item`
@@ -45,11 +46,10 @@ class _EditItemDialogState extends State<EditItemDialog> {
         ],
       ),
       actions: [
-        ElevatedButton(
+        SubmitButton(
           // if the text value for the item is blank, this button is disabled (onPressed == null),
           // because we don't want the user to be able to submit blank/empty items.
-          onPressed: !_isValueBlank ? _submitNewItemValue : null,
-          child: const Text('Submit'),
+          onPressed: !_isValueBlank ? _submitNewItemValue : null
         )
       ],
     );

--- a/lib/view/editing_actions_modal_bottom_sheet.dart
+++ b/lib/view/editing_actions_modal_bottom_sheet.dart
@@ -42,14 +42,6 @@ class EditingActionButton extends StatelessWidget {
           label: 'Delete',
           color: Colors.red);
 
-  factory EditingActionButton.editButton(
-          {required void Function() onPressed}) =>
-      EditingActionButton(
-          onPressed: onPressed,
-          icon: Icons.edit,
-          label: 'Edit',
-          color: Colors.lightGreen);
-
   @override
   Widget build(BuildContext context) {
     return TextButton.icon(

--- a/lib/view/list_preview_widget.dart
+++ b/lib/view/list_preview_widget.dart
@@ -40,7 +40,7 @@ class _ListPreviewWidgetState extends State<ListPreviewWidget> {
             MaterialPageRoute(builder: (_) => ListWidget(widget.listModel)));
         setState(() {});
       },
-      onLongPress: _showOptionsModalSheet,
+      onLongPress: _showListSettingsDialog,
       child: Row(
         children: [
           const Padding(
@@ -89,14 +89,7 @@ class _ListPreviewWidgetState extends State<ListPreviewWidget> {
     );
   }
 
-  void _showOptionsModalSheet() {
-    showModalBottomSheet(
-      context: context,
-      builder: (context) => EditingActionsModalBottomSheet(
-        actionButtons: [
-          EditingActionButton.deleteButton(onDelete: widget.onDelete),
-          EditingActionButton.editButton(
-              onPressed: () => showDialog(
+  void _showListSettingsDialog() => showDialog(
                   context: context,
                   builder: (context) => ListSettingsDialog(
                       onSubmit: (listModel) async {
@@ -104,10 +97,9 @@ class _ListPreviewWidgetState extends State<ListPreviewWidget> {
                         setState(() {});
                         widget.onEdited();
                       },
+                      onDelete: ()=>
+                        widget.onDelete(),
+                      
                       listModel: widget.listModel,
-                      allLabels: widget.allLabels))),
-        ],
-      ),
-    );
-  }
+                      allLabels: widget.allLabels));
 }

--- a/lib/view/list_settings_dialog.dart
+++ b/lib/view/list_settings_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:lists/model/list_model.dart';
 import 'package:lists/view/add_label_dialog.dart';
+import 'package:lists/view/editing_actions_modal_bottom_sheet.dart';
 
 /// ListSettingsDialog:
 ///   - a dialog that allows the user to edit the metadata of the list
@@ -8,12 +9,14 @@ class ListSettingsDialog extends StatefulWidget {
   final void Function(ListModel) onSubmit;
   final ListModel listModel;
   final Iterable<String> allLabels;
+  final void Function()? onDelete;
 
   const ListSettingsDialog(
       {super.key,
       required this.onSubmit,
       required this.listModel,
-      required this.allLabels});
+      required this.allLabels,
+      this.onDelete});
 
   @override
   State<ListSettingsDialog> createState() => _ListSettingsDialogState();
@@ -81,12 +84,28 @@ class _ListSettingsDialogState extends State<ListSettingsDialog> {
         ],
       ),
       actions: [
+        if (widget.onDelete != null)
+          ElevatedButton.icon(
+              icon: const Icon(Icons.delete),
+              label: const Text('Delete'),
+              onPressed: () {
+                Navigator.pop(context);
+                widget.onDelete?.call();
+              },
+              style: const ButtonStyle(
+                  foregroundColor: MaterialStatePropertyAll(Colors.red))),
         ElevatedButton(
           // if the title is blank, this button is disabled (onPressed == null),
           // because we don't want the user to be able to submit lists with blank titles.
           onPressed: !_isTitleBlank ? _submitListModel : null,
           child: const Text('Submit'),
-        )
+        ),
+        // ElevatedButton(
+        //   // if the title is blank, this button is disabled (onPressed == null),
+        //   // because we don't want the user to be able to submit lists with blank titles.
+        //   onPressed: !_isTitleBlank ? _submitListModel : null,
+        //   child: const Text('Submit'),
+        // ),
       ],
     );
   }

--- a/lib/view/list_settings_dialog.dart
+++ b/lib/view/list_settings_dialog.dart
@@ -85,16 +85,15 @@ class _ListSettingsDialogState extends State<ListSettingsDialog> {
       ),
       actions: [
         if (widget.onDelete != null)
-          ElevatedButton.icon(
-              icon: const Icon(Icons.delete),
-              label: const Text('Delete'),
+          TextButton(
               onPressed: () {
                 Navigator.pop(context);
                 widget.onDelete?.call();
               },
               style: const ButtonStyle(
-                  foregroundColor: MaterialStatePropertyAll(Colors.red))),
-        ElevatedButton(
+                  foregroundColor: MaterialStatePropertyAll(Colors.red)),
+              child: const Text('Delete')),
+        FilledButton(
           // if the title is blank, this button is disabled (onPressed == null),
           // because we don't want the user to be able to submit lists with blank titles.
           onPressed: !_isTitleBlank ? _submitListModel : null,

--- a/lib/view/list_settings_dialog.dart
+++ b/lib/view/list_settings_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lists/model/list_model.dart';
 import 'package:lists/view/add_label_dialog.dart';
 import 'package:lists/view/editing_actions_modal_bottom_sheet.dart';
+import 'package:lists/view/submit_button.dart';
 
 /// ListSettingsDialog:
 ///   - a dialog that allows the user to edit the metadata of the list
@@ -93,11 +94,10 @@ class _ListSettingsDialogState extends State<ListSettingsDialog> {
               style: const ButtonStyle(
                   foregroundColor: MaterialStatePropertyAll(Colors.red)),
               child: const Text('Delete')),
-        FilledButton(
+        SubmitButton(
           // if the title is blank, this button is disabled (onPressed == null),
           // because we don't want the user to be able to submit lists with blank titles.
-          onPressed: !_isTitleBlank ? _submitListModel : null,
-          child: const Text('Submit'),
+          onPressed: !_isTitleBlank ? _submitListModel : null
         ),
       ],
     );

--- a/lib/view/list_settings_dialog.dart
+++ b/lib/view/list_settings_dialog.dart
@@ -100,12 +100,6 @@ class _ListSettingsDialogState extends State<ListSettingsDialog> {
           onPressed: !_isTitleBlank ? _submitListModel : null,
           child: const Text('Submit'),
         ),
-        // ElevatedButton(
-        //   // if the title is blank, this button is disabled (onPressed == null),
-        //   // because we don't want the user to be able to submit lists with blank titles.
-        //   onPressed: !_isTitleBlank ? _submitListModel : null,
-        //   child: const Text('Submit'),
-        // ),
       ],
     );
   }

--- a/lib/view/submit_button.dart
+++ b/lib/view/submit_button.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class SubmitButton extends StatelessWidget {
+  final void Function()? onPressed;
+  const SubmitButton({this.onPressed, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton(onPressed: onPressed, child: const Text('Submit'));
+  }
+}


### PR DESCRIPTION
Now, the delete button is:
- An `ElevatedButton` (to be consistent with the submit button; used to be a `TextButton`); and
- In the `ListSettingsDialog` (at least, when a list is being edited; a dialog for a new list doesn't have the delete action button).

I removed the `EditingActionButton.editButton` constructor, since it was only used in the modal bottom sheet for `ListModel`s.

Closes #34 