### PR TITLE
Clean up reordering logic

### DIFF
--- a/lib/model/list_model.dart
+++ b/lib/model/list_model.dart
@@ -50,7 +50,8 @@ class ListModel {
   }
 
   Future<void> add(Item newItem) async {
-    newItem.order = itemCount;
+    // Use an order value larger than the largest order value.
+    newItem.order = (maxBy(items, (item) => item.order)?.order ?? -1) + 1;
     await DatabaseManager.putItem(newItem);
     if (items.add(newItem)) {
       await DatabaseManager.updateListModelItems(this);
@@ -75,14 +76,7 @@ class ListModel {
 
   Future<void> remove(Item item) async {
     if (items.remove(item)) {
-      final itemsOrderedAfterRemovedItem =
-          await items.filter().orderGreaterThan(item.order).findAll();
-      for (final item in itemsOrderedAfterRemovedItem) {
-        --item.order;
-      }
-
       await DatabaseManager.deleteItem(item);
-      await DatabaseManager.putItems(itemsOrderedAfterRemovedItem);
       await DatabaseManager.updateListModelItems(this);
       _eventStreamController.add(ListModelEvent.itemRemoved);
     }
@@ -91,32 +85,8 @@ class ListModel {
   /// Gets the `Item` stored in `IsarLinks` with `item`'s id.
   Item lookup(Item item) => items.lookup(item)!;
 
-  void reorderItem({required int oldOrder, required int newOrder}) {
-    assert(oldOrder < items.length && oldOrder >= 0);
-    assert(newOrder < items.length && newOrder >= 0);
-
-    int lower = min(oldOrder, newOrder);
-    int upper = max(oldOrder, newOrder);
-
-    final itemsToReorder = items
-        .filter()
-        .orderBetween(lower, upper)
-        .findAllSync()
-        // lookup all the items so that the new orderings are instantly/synchronously reflected
-        // in the `IsarLinks` copy of the database items.
-        .map((item) => lookup(item));
-    // note: we can use `findFirst` since there should be exactly one
-    // element ordered with `oldOrder`.
-    final itemWithOldOrder =
-        lookup(items.filter().orderEqualTo(oldOrder).findFirstSync()!);
-    final reorderingOffset = (oldOrder - newOrder).sign;
-
-    for (final item in itemsToReorder) {
-      item.order += reorderingOffset;
-    }
-
-    itemWithOldOrder.order = newOrder;
-    DatabaseManager.putItems([...itemsToReorder, itemWithOldOrder]);
+  reorderItems(List<Item> items) async {
+    await DatabaseManager.putItems(items);
   }
 
   Future<Iterable<Item>> searchItems(String searchQuery) {

--- a/lib/view/list_widget.dart
+++ b/lib/view/list_widget.dart
@@ -76,25 +76,16 @@ class _ListWidgetState extends State<ListWidget> {
         ? ReorderableSliverList(
             delegate: ReorderableSliverChildListDelegate(
                 _buildItemWidgets(fromItems: unCheckedItems)),
-            // Note onReorder can't be async (which would allow us to `await` for the
-            // ordering of the items to be updated) because if it was, the list would
-            // sometimes flicker briefly between the old ordering and the new ordering (tested).
             onReorder: (oldIndex, newIndex) {
-              int oldOrder = unCheckedItems[oldIndex].order;
-              int newOrder = unCheckedItems[newIndex].order;
-              listModel.reorderItem(oldOrder: oldOrder, newOrder: newOrder);
-              // We set `itemsToBeDisplayed` to `listModel.itemsView()` because
-              // 1) `reorderItem` uses `DatabaseManager.putItems` to update the ordering of the
-              // items, which is asynchronous, meaning that the items in the database may not be
-              // updated. However the function does update the `IsarLinks` cached copy
-              // of the items (which is `listModel.itemsView()`) synchronously. Also,
-              // 2) if the user previously searched the items, then `itemsToBeDisplayed`
-              // holds a copy of the `listModel`'s items separate from the `IsarLinks`, and
-              // so is not updated.
-              // So, `listModel.itemsView()` holds the only updated copy of the
-              // `listModel`'s items.
-
-              setState(() => itemsToBeDisplayed = listModel.itemsView());
+              // Move the item
+              var item = unCheckedItems.removeAt(oldIndex);
+              unCheckedItems.insert(newIndex, item);
+              // Update the order values
+              var combined = unCheckedItems + checkedItems;
+              combined
+                  .forEachIndexed((index, element) => element.order = index);
+              // Save to DB
+              listModel.reorderItems(combined);
             },
             onDragStart: () => setState(() => isReordering = true),
             onDragEnd: () => setState(() => isReordering = false),
@@ -117,10 +108,14 @@ class _ListWidgetState extends State<ListWidget> {
     ]);
   }
 
-  List<Widget> _buildItemWidgets({required Iterable<Item> fromItems, bool tappable = true}) =>
-      fromItems.map((item) => ItemWidget(item,tappable: tappable,  onDelete: () async =>
-            await listModel.remove(item), onEdited: () async =>
-            await listModel.update(item))).toList();
+  List<Widget> _buildItemWidgets(
+          {required Iterable<Item> fromItems, bool tappable = true}) =>
+      fromItems
+          .map((item) => ItemWidget(item,
+              tappable: tappable,
+              onDelete: () async => await listModel.remove(item),
+              onEdited: () async => await listModel.update(item)))
+          .toList();
 
   void _addNewItem() async {
     // Imitate the type of the last item.
@@ -130,8 +125,7 @@ class _ListWidgetState extends State<ListWidget> {
       showDialog(
         context: context,
         builder: (context) => EditItemDialog(
-            onSubmit: (newItem) async =>
-              await listModel.add(newItem),
+            onSubmit: (newItem) async => await listModel.add(newItem),
             item: newItem),
       );
     }
@@ -144,11 +138,11 @@ class _ListWidgetState extends State<ListWidget> {
 
   List<Item> _ordered(Iterable<Item> items) =>
       items.sorted((a, b) => a.order - b.order);
-      
+
   @override
   void dispose() {
     // Note we don't need to await for the subscription to cancel;
-    // this call is needed just so that unneeded and unreferenced 
+    // this call is needed just so that unneeded and unreferenced
     // subscriptions are removed from listModel's eventStream.
     eventStreamSubscription.cancel();
     super.dispose();


### PR DESCRIPTION
Cleaned up the re-ordering logic, so we don't need `reorderItems` to be sync.